### PR TITLE
debug isn't a dev dependency if its required

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/tessel/usb-daemon-parser/issues"
   },
   "homepage": "https://github.com/tessel/usb-daemon-parser",
-  "devDependencies": {
+  "dependencies": {
     "debug": "^2.1.3"
   }
 }


### PR DESCRIPTION
This is preventing the test rig from running properly since debug isn't installed 
